### PR TITLE
Add format presets for `/nick`

### DIFF
--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -47,7 +47,7 @@ private const val VERSION = "0.1.0-SNAPSHOT"
     version = VERSION,
     url = "https://openredstone.org",
     description = "Because we want to have a chat system that actually wOREks for us.",
-    authors = ["Nickster258", "PaukkuPalikka", "StackDoubleFlow"],
+    authors = ["Nickster258", "PaukkuPalikka", "StackDoubleFlow", "sodiboo"],
     dependencies = [Dependency(id = "luckperms")]
 )
 class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @DataDirectory dataFolder: Path) {

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -121,6 +121,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             commandCompletions.registerCompletion("bool") { listOf("true", "false")}
             commandCompletions.registerCompletion("emojis") { emojis.keys }
             commandCompletions.registerCompletion("usernameCache") { database.uuidToUsernameCache.values }
+            commandCompletions.registerCompletion("username") { listOf(it.player.username) }
             commandCompletions.registerCompletion("uuidAndUsernameCache") {
                 database.uuidToUsernameCache.values + database.uuidToUsernameCache.keys.map { it.toString() }
             }

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -139,7 +139,10 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             mapOf(
                 "about" to (this.database.getAbout(user.uniqueId) ?: "no about yet :(").toComponent(),
                 "ign" to ign.toComponent(),
-                "nickname" to (this.database.getNickname(user.uniqueId) ?: "No nickname set").miniMessageDeserialize(),
+                "nickname" to (this.database.getNickname(user.uniqueId) ?: "No nickname set")
+                    .render(mapOf(
+                        "username" to ign.toComponent(),
+                    )),
                 "rank" to group.legacyDeserialize(),
             )
         )

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -229,7 +229,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         ).clickEvent(
             ClickEvent.runCommand("/playerprofile info ${player.username}")
         )
-        val prefix = luckUser.cachedData.metaData.prefix ?: return
+        val prefix = luckUser.cachedData.metaData.prefix ?: luckUser.cachedData.metaData.primaryGroup?.replaceFirstChar(Char::uppercaseChar) ?: "No Group"
         broadcast(
             config[ChattORESpec.format.global].render(
                 mapOf(

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -125,6 +125,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             commandCompletions.registerCompletion("uuidAndUsernameCache") {
                 database.uuidToUsernameCache.values + database.uuidToUsernameCache.keys.map { it.toString() }
             }
+            commandCompletions.registerCompletion("pridePresets") { pridePresets.keys }
         }
         proxy.eventManager.register(this, ChatListener(this))
     }

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -54,7 +54,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     lateinit var luckPerms: LuckPerms
     lateinit var config: Config
     lateinit var database: Storage
-    lateinit var discordNetwork: DiscordApi
+    var discordNetwork: DiscordApi? = null
     val onlinePlayers: MutableSet<UUID> = Collections.synchronizedSet(mutableSetOf())
     private val replyMap: MutableMap<UUID, UUID> = hashMapOf()
     private var discordMap: Map<String, DiscordApi> = hashMapOf()
@@ -215,7 +215,8 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     }
 
     fun broadcastPlayerConnection(message: String) {
-        discordNetwork.getTextChannelById(config[ChattORESpec.discord.channelId]).ifPresent {
+        val discord = discordNetwork ?: return
+        discord.getTextChannelById(config[ChattORESpec.discord.channelId])?.ifPresent {
             it.sendMessage(message)
         }
     }

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -55,7 +55,6 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     lateinit var config: Config
     lateinit var database: Storage
     var discordNetwork: DiscordApi? = null
-    val onlinePlayers: MutableSet<UUID> = Collections.synchronizedSet(mutableSetOf())
     private val replyMap: MutableMap<UUID, UUID> = hashMapOf()
     private var discordMap: Map<String, DiscordApi> = hashMapOf()
     private var emojis: Map<String, String> = hashMapOf()

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -232,7 +232,9 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         ).clickEvent(
             ClickEvent.runCommand("/playerprofile info ${player.username}")
         )
-        val prefix = luckUser.cachedData.metaData.prefix ?: luckUser.cachedData.metaData.primaryGroup?.replaceFirstChar(Char::uppercaseChar) ?: "No Group"
+        val prefix = luckUser.cachedData.metaData.prefix
+            ?: luckUser.primaryGroup.replaceFirstChar(Char::uppercaseChar)
+
         broadcast(
             config[ChattORESpec.format.global].render(
                 mapOf(

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -230,12 +230,11 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         val name = this.database.getNickname(user) ?: this.proxy.getPlayer(user).get().username
         val player = this.proxy.getPlayer(user).get()
         val sender = name.render(mapOf(
-            "username" to Component.text(player.username)
-        )).hoverEvent(
-            HoverEvent.showText("${player.username} | <i>Click for more</i>".miniMessageDeserialize())
-        ).clickEvent(
-            ClickEvent.runCommand("/playerprofile info ${player.username}")
-        )
+            "username" to player.username.toComponent()
+        )).let {
+            "<click:run_command:'/playerprofile info ${player.username}'><message></click>".render(it)
+        };
+
         val prefix = luckUser.cachedData.metaData.prefix
             ?: luckUser.primaryGroup.replaceFirstChar(Char::uppercaseChar)
 
@@ -244,7 +243,8 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
                 mapOf(
                     "message" to message.prepareChatMessage(chatReplacements),
                     "sender" to sender,
-                    "prefix" to prefix.legacyDeserialize()
+                    "username" to Component.text(player.username),
+                    "prefix" to prefix.legacyDeserialize(),
                 )
             )
         )

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -125,7 +125,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             commandCompletions.registerCompletion("uuidAndUsernameCache") {
                 database.uuidToUsernameCache.values + database.uuidToUsernameCache.keys.map { it.toString() }
             }
-            commandCompletions.registerCompletion("pridePresets") { pridePresets.keys }
+            commandCompletions.registerCompletion("nickPresets") { config[ChattORESpec.nicknamePresets].keys }
         }
         proxy.eventManager.register(this, ChatListener(this))
     }
@@ -225,7 +225,9 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         val luckUser = userManager.getUser(user) ?: return
         val name = this.database.getNickname(user) ?: this.proxy.getPlayer(user).get().username
         val player = this.proxy.getPlayer(user).get()
-        val sender = name.miniMessageDeserialize().hoverEvent(
+        val sender = name.render(mapOf(
+            "username" to Component.text(player.username)
+        )).hoverEvent(
             HoverEvent.showText("${player.username} | <i>Click for more</i>".miniMessageDeserialize())
         ).clickEvent(
             ClickEvent.runCommand("/playerprofile info ${player.username}")

--- a/src/main/kotlin/Pride.kt
+++ b/src/main/kotlin/Pride.kt
@@ -521,4 +521,6 @@ val prideColors = mapOf(
     ),
 )
 
-val pridePresets = prideColors.mapValues { (_, colors) -> "<gradient:${colors.joinToString(':'.toString())}><username></gradient>" }.toSortedMap()
+val pridePresets = prideColors.mapValues { (_, colors) ->
+        "<gradient:${colors.joinToString(':'.toString())}><username></gradient>"
+    }.toSortedMap()

--- a/src/main/kotlin/Pride.kt
+++ b/src/main/kotlin/Pride.kt
@@ -3,11 +3,12 @@
 
 package chattore;
 
+import chattore.prideColors
+
 fun weighted(vararg colors: Pair<String, Int>): Array<String> =
         colors.flatMap { (value, weight) -> List(weight) { value } }.toTypedArray()
 
-
-val pridePresets = mapOf(
+val prideColors = mapOf(
     "rainbow" to arrayOf(
         "#E50000",
         "#FF8D00",
@@ -518,4 +519,6 @@ val pridePresets = mapOf(
         "#243897",
         "#6F0A82",
     ),
-);
+)
+
+val pridePresets = prideColors.mapValues { (_, colors) -> "<gradient:${colors.joinToString(':'.toString())}><username></gradient>" }.toSortedMap()

--- a/src/main/kotlin/Pride.kt
+++ b/src/main/kotlin/Pride.kt
@@ -1,0 +1,521 @@
+// This file is based on hyfetch, and was last updated 2024-06-12
+// https://github.com/hykilpikonna/hyfetch/blob/7534371b05ee877cd3c4c3733b13d7c41d09c3e/hyfetch/presets.py
+
+package chattore;
+
+fun weighted(vararg colors: Pair<String, Int>): Array<String> =
+        colors.flatMap { (value, weight) -> List(weight) { value } }.toTypedArray()
+
+
+val pridePresets = mapOf(
+    "rainbow" to arrayOf(
+        "#E50000",
+        "#FF8D00",
+        "#FFEE00",
+        "#028121",
+        "#004CFF",
+        "#770088"
+    ),
+
+    "transgender" to arrayOf(
+        "#55CDFD",
+        "#F6AAB7",
+        "#FFFFFF",
+        "#F6AAB7",
+        "#55CDFD"
+    ),
+
+    "nonbinary" to arrayOf(
+        "#FCF431",
+        "#FCFCFC",
+        "#9D59D2",
+        "#282828"
+    ),
+
+    "agender" to arrayOf(
+        "#000000",
+        "#BABABA",
+        "#FFFFFF",
+        "#BAF484",
+        "#FFFFFF",
+        "#BABABA",
+        "#000000"
+    ),
+
+    "queer" to arrayOf(
+        "#B57FDD",
+        "#FFFFFF",
+        "#49821E"
+    ),
+
+    "genderfluid" to arrayOf(
+        "#FE76A2",
+        "#FFFFFF",
+        "#BF12D7",
+        "#000000",
+        "#303CBE"
+    ),
+
+    "bisexual" to arrayOf(
+        "#D60270",
+        "#9B4F96",
+        "#0038A8"
+    ),
+
+    "pansexual" to arrayOf(
+        "#FF1C8D",
+        "#FFD700",
+        "#1AB3FF"
+    ),
+
+    "polysexual" to arrayOf(
+        "#F714BA",
+        "#01D66A",
+        "#1594F6",
+    ),
+
+    "omnisexual" to arrayOf(
+        "#FE9ACE",
+        "#FF53BF",
+        "#200044",
+        "#6760FE",
+        "#8EA6FF",
+    ),
+
+    "omniromantic" to arrayOf(
+        "#FEC8E4",
+        "#FDA1DB",
+        "#89739A",
+        "#ABA7FE",
+        "#BFCEFF",
+    ),
+
+    "gay-men" to arrayOf(
+        "#078D70",
+        "#98E8C1",
+        "#FFFFFF",
+        "#7BADE2",
+        "#3D1A78"
+    ),
+
+    "lesbian" to arrayOf(
+        "#D62800",
+        "#FF9B56",
+        "#FFFFFF",
+        "#D462A6",
+        "#A40062"
+    ),
+
+    "abrosexual" to arrayOf(
+        "#46D294",
+        "#A3E9CA",
+        "#FFFFFF",
+        "#F78BB3",
+        "#EE1766",
+    ),
+
+    "asexual" to arrayOf(
+        "#000000",
+        "#A4A4A4",
+        "#FFFFFF",
+        "#810081"
+    ),
+
+    "aromantic" to arrayOf(
+        "#3BA740",
+        "#A8D47A",
+        "#FFFFFF",
+        "#ABABAB",
+        "#000000"
+    ),
+
+    "aroace1" to arrayOf(
+        "#E28C00",
+        "#ECCD00",
+        "#FFFFFF",
+        "#62AEDC",
+        "#203856"
+    ),
+
+    "aroace2" to arrayOf(
+        "#000000",
+        "#810081",
+        "#A4A4A4",
+        "#FFFFFF",
+        "#A8D47A",
+        "#3BA740"
+    ),
+
+    "aroace3" to arrayOf(
+        "#3BA740",
+        "#A8D47A",
+        "#FFFFFF",
+        "#ABABAB",
+        "#000000",
+        "#A4A4A4",
+        "#FFFFFF",
+        "#810081"
+    ),
+
+    "autosexual" to arrayOf(
+        "#99D9EA",
+        "#7F7F7F"
+    ),
+
+    "intergender" to arrayOf(
+        "#900DC2",
+        "#900DC2",
+        "#FFE54F",
+        "#900DC2",
+        "#900DC2",
+    ),
+
+    "greygender" to arrayOf(
+        "#B3B3B3",
+        "#B3B3B3",
+        "#FFFFFF",
+        "#062383",
+        "#062383",
+        "#FFFFFF",
+        "#535353",
+        "#535353",
+    ),
+
+    "akiosexual" to arrayOf(
+        "#F9485E",
+        "#FEA06A",
+        "#FEF44C",
+        "#FFFFFF",
+        "#000000",
+    ),
+
+    "bigender" to arrayOf(
+        "#C479A2",
+        "#EDA5CD",
+        "#D6C7E8",
+        "#FFFFFF",
+        "#D6C7E8",
+        "#9AC7E8",
+        "#6D82D1",
+    ),
+
+    "demigender" to arrayOf(
+        "#7F7F7F",
+        "#C4C4C4",
+        "#FBFF75",
+        "#FFFFFF",
+        "#FBFF75",
+        "#C4C4C4",
+        "#7F7F7F",
+    ),
+
+    "demiboy" to arrayOf(
+        "#7F7F7F",
+        "#C4C4C4",
+        "#9DD7EA",
+        "#FFFFFF",
+        "#9DD7EA",
+        "#C4C4C4",
+        "#7F7F7F",
+    ),
+
+    "demigirl" to arrayOf(
+        "#7F7F7F",
+        "#C4C4C4",
+        "#FDADC8",
+        "#FFFFFF",
+        "#FDADC8",
+        "#C4C4C4",
+        "#7F7F7F",
+    ),
+
+    "transmasculine" to arrayOf(
+        "#FF8ABD",
+        "#CDF5FE",
+        "#9AEBFF",
+        "#74DFFF",
+        "#9AEBFF",
+        "#CDF5FE",
+        "#FF8ABD",
+    ),
+
+    "transfeminine" to arrayOf(
+        "#73DEFF",
+        "#FFE2EE",
+        "#FFB5D6",
+        "#FF8DC0",
+        "#FFB5D6",
+        "#FFE2EE",
+        "#73DEFF",
+    ),
+
+    "genderfaun" to arrayOf(
+        "#FCD689",
+        "#FFF09B",
+        "#FAF9CD",
+        "#FFFFFF",
+        "#8EDED9",
+        "#8CACDE",
+        "#9782EC",
+    ),
+
+    "demifaun" to arrayOf(
+        "#7F7F7F",
+        "#7F7F7F",
+        "#C6C6C6",
+        "#C6C6C6",
+        "#FCC688",
+        "#FFF19C",
+        "#FFFFFF",
+        "#8DE0D5",
+        "#9682EC",
+        "#C6C6C6",
+        "#C6C6C6",
+        "#7F7F7F",
+        "#7F7F7F",
+    ),
+
+    "genderfae" to arrayOf(
+        "#97C3A5",
+        "#C3DEAE",
+        "#F9FACD",
+        "#FFFFFF",
+        "#FCA2C4",
+        "#DB8AE4",
+        "#A97EDD",
+    ),
+
+    "demifae" to arrayOf(
+        "#7F7F7F",
+        "#7F7F7F",
+        "#C5C5C5",
+        "#C5C5C5",
+        "#97C3A4",
+        "#C4DEAE",
+        "#FFFFFF",
+        "#FCA2C5",
+        "#AB7EDF",
+        "#C5C5C5",
+        "#C5C5C5",
+        "#7F7F7F",
+        "#7F7F7F",
+    ),
+
+    "neutrois" to arrayOf(
+        "#FFFFFF",
+        "#1F9F00",
+        "#000000"
+    ),
+
+    "biromantic1" to arrayOf(
+        "#8869A5",
+        "#D8A7D8",
+        "#FFFFFF",
+        "#FDB18D",
+        "#151638",
+    ),
+
+    "biromantic2" to arrayOf(
+        "#740194",
+        "#AEB1AA",
+        "#FFFFFF",
+        "#AEB1AA",
+        "#740194",
+    ),
+
+    "autoromantic" to arrayOf(
+        "#99D9EA",
+        "#99D9EA",
+        "#3DA542",
+        "#7F7F7F",
+        "#7F7F7F",
+    ),
+
+    "boyflux2" to weighted(
+        Pair("#E48AE4",1),
+        Pair("#9A81B4",1),
+        Pair("#55BFAB",1),
+        Pair("#FFFFFF",1),
+        Pair("#A8A8A8",1),
+        Pair("#81D5EF",5),
+        Pair("#69ABE5",5),
+        Pair("#5276D4",5),
+    ),
+
+    "girlflux" to arrayOf(
+        "#F9E6D7",
+        "#F2526C",
+        "#BF0311",
+        "#E9C587",
+        "#BF0311",
+        "#F2526C",
+        "#F9E6D7",
+    ),
+
+    "genderflux" to arrayOf(
+        "#F47694",
+        "#F2A2B9",
+        "#CECECE",
+        "#7CE0F7",
+        "#3ECDF9",
+        "#FFF48D",
+    ),
+
+    "finsexual" to arrayOf(
+        "#B18EDF",
+        "#D7B1E2",
+        "#F7CDE9",
+        "#F39FCE",
+        "#EA7BB3",
+    ),
+
+    "unlabeled1" to arrayOf(
+        "#EAF8E4",
+        "#FDFDFB",
+        "#E1EFF7",
+        "#F4E2C4"
+    ),
+
+    "unlabeled2" to arrayOf(
+        "#250548",
+        "#FFFFFF",
+        "#F7DCDA",
+        "#EC9BEE",
+        "#9541FA",
+        "#7D2557"
+    ),
+
+    "pangender" to arrayOf(
+        "#FFF798",
+        "#FEDDCD",
+        "#FFEBFB",
+        "#FFFFFF",
+        "#FFEBFB",
+        "#FEDDCD",
+        "#FFF798",
+    ),
+
+    "gendernonconforming1" to weighted(
+        Pair("#50284D",4),
+        Pair("#96467B",1),
+        Pair("#5C96F7",1),
+        Pair("#FFE6F7",1),
+        Pair("#5C96F7",1),
+        Pair("#96467B",1),
+        Pair("#50284D",4),
+    ),
+
+    "gendernonconforming2" to arrayOf(
+        "#50284D",
+        "#96467B",
+        "#5C96F7",
+        "#FFE6F7",
+        "#5C96F7",
+        "#96467B",
+        "#50284D"
+    ),
+
+    "femboy" to arrayOf(
+        "#D260A5",
+        "#E4AFCD",
+        "#FEFEFE",
+        "#57CEF8",
+        "#FEFEFE",
+        "#E4AFCD",
+        "#D260A5"
+    ),
+
+    "tomboy" to arrayOf(
+        "#2F3FB9",
+        "#613A03",
+        "#FEFEFE",
+        "#F1A9B7",
+        "#FEFEFE",
+        "#613A03",
+        "#2F3FB9"
+    ),
+
+    "gynesexual" to arrayOf(
+        "#F4A9B7",
+        "#903F2B",
+        "#5B953B",
+    ),
+
+    "androsexual" to arrayOf(
+        "#01CCFF",
+        "#603524",
+        "#B799DE",
+    ),
+
+    "gendervoid" to arrayOf(
+        "#081149",
+        "#4B484B",
+        "#000000",
+        "#4B484B",
+        "#081149"
+    ),
+
+    "voidgirl" to arrayOf(
+        "#180827",
+        "#7A5A8B",
+        "#E09BED",
+        "#7A5A8B",
+        "#180827"
+    ),
+
+    "voidboy" to arrayOf(
+        "#0B130C",
+        "#547655",
+        "#66B969",
+        "#547655",
+        "#0B130C"
+    ),
+
+    "nonhuman-unity" to arrayOf(
+        "#177B49",
+        "#FFFFFF",
+        "#593C90"
+    ),
+
+    "plural" to arrayOf(
+        "#2D0625",
+        "#543475",
+        "#7675C3",
+        "#89C7B0",
+        "#F3EDBD",
+    ),
+
+    "fraysexual" to arrayOf(
+        "#226CB5",
+        "#94E7DD",
+        "#FFFFFF",
+        "#636363",
+    ),
+
+    "beiyang" to arrayOf(
+        "#DF1B12",
+        "#FFC600",
+        "#01639D",
+        "#FFFFFF",
+        "#000000",
+    ),
+
+    "burger" to arrayOf(
+        "#F3A26A",
+        "#498701",
+        "#FD1C13",
+        "#7D3829",
+        "#F3A26A",
+    ),
+
+    "baker" to arrayOf(
+        "#F23D9E",
+        "#F80A24",
+        "#F78022",
+        "#F9E81F",
+        "#1E972E",
+        "#1B86BC",
+        "#243897",
+        "#6F0A82",
+    ),
+);

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -58,16 +58,18 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
         // Note: worth having a timeout to prevent people from changing too frequently.
         if (colors.isEmpty()) throw ChattoreException("No colors provided! Please provide 1 to 3 colors!")
         val rendered = if (colors.size == 1) {
-            val code = "<${colors.first().validateColor()}>"
-            val nickname = "${code}${player.username}<reset>"
+            val color = colors.first().validateColor();
+            val nickname = "<color:$color><username></color:$color>"
             chattORE.database.setNickname(player.uniqueId, nickname)
             nickname
         } else {
             if (colors.size > 3) throw ChattoreException("Too many colors!")
-            setNicknameGradient(player.uniqueId, player.username, *colors)
+            setNicknameGradient(player.uniqueId, *colors)
         }
         val response = chattORE.config[ChattORESpec.format.chattore].render(
-            "Your nickname has been set to $rendered".miniMessageDeserialize()
+            "Your nickname has been set to $rendered".render(mapOf(
+                "username" to Component.text(player.username)
+            ))
         )
         player.sendMessage(response)
     }
@@ -158,10 +160,9 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
         }
     }
 
-    private fun setNicknameGradient(uniqueId: UUID, username: String, vararg colors: String): String {
-        val codes = colors.map { it.validateColor() }
-        val tag = "<gradient:${codes.joinToString(':'.toString())}>"
-        val nickname = "$tag$username<reset>"
+    private fun setNicknameGradient(uniqueId: UUID, vararg colors: String): String {
+        val codes = colors.map { it.validateColor() }.joinToString(":");
+        val nickname = "<gradient:$codes><username></gradient>"
         chattORE.database.setNickname(uniqueId, nickname)
         return nickname
     }

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -79,6 +79,7 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
     }
 
     @Subcommand("preset")
+    @CommandPermission("chattore.nick.preset")
     @CommandCompletion("@nickPresets")
     fun pride(player: Player, preset: String) {
         val format = chattORE.config[ChattORESpec.nicknamePresets][preset]
@@ -92,6 +93,7 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
     }
 
     @Subcommand("presets")
+    @CommandPermission("chattore.nick.preset")
     @CommandCompletion("@username")
     fun presets(player: Player, @Optional shownText: String?) {
         var renderedPresets = ArrayList<Component>()

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -105,22 +105,18 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
             }
             val rendered = if (shownText == null) {
                 // Primarily show the preset name, else a preview of the nickname.
-                applyPreset(presetName).hoverEvent(
-                    HoverEvent.showText(
-                        "Click to apply <message>".render(applyPreset(player.username))
-                    )
-                )
+                "<hover:show_text:'Click to apply <username>'><preset></hover>"
             } else {
                 // Primarily show the entered text, else the preset name.
                 // Also, we're suggesting the username as the autocompleted $shownText.
-                applyPreset(shownText).hoverEvent(
-                    HoverEvent.showText(
-                        "Click to apply <message> preset".render(applyPreset(presetName))
-                    )
-                )
-            }.clickEvent(
-                ClickEvent.runCommand("/nick preset $presetName")
-            )
+                "<hover:show_text:'Click to apply <preset> preset'><custom></hover>"
+            }.render(mapOf(
+                "username" to applyPreset(player.username),
+                "preset" to applyPreset(presetName),
+                "custom" to applyPreset(shownText ?: "")
+            )).let {
+                "<click:run_command:'/nick preset $presetName'><message></click>".render(it)
+            }
             renderedPresets.add(rendered)
         }
 

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -71,6 +71,31 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
         player.sendMessage(response)
     }
 
+    @Subcommand("pride")
+    @CommandCompletion("@pridePresets")
+    fun pride(player: Player, flag: String) {
+        val colors = pridePresets[flag]
+            ?: throw ChattoreException("Unknown pride flag! Use /nick presets to see available flags.")
+        val rendered = setNicknameGradient(player.uniqueId, player.username, *colors)
+        val response = chattORE.config[ChattORESpec.format.chattore].render(
+            "Your nickname has been set to $rendered".miniMessageDeserialize()
+        )
+        player.sendMessage(response)
+    }
+
+    @Subcommand("presets")
+    fun presets(player: Player) {
+        var renderedPresets = ArrayList<String>()
+        for ((name, colors) in pridePresets) {
+            renderedPresets.add("<gradient:${colors.joinToString(':'.toString())}>$name<reset>")
+        }
+
+        val response = chattORE.config[ChattORESpec.format.chattore].render(
+            "Available pride presets: ${renderedPresets.joinToString(", ")}".miniMessageDeserialize()
+        )
+        player.sendMessage(response)
+    }
+
     @Subcommand("nick")
     @CommandPermission("chattore.nick.others")
     @CommandCompletion("@usernameCache")

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -8,6 +8,7 @@ import com.velocitypowered.api.command.CommandSource
 import com.velocitypowered.api.proxy.Player
 import java.util.*
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.JoinConfiguration
 
 // TODO: 8/23/2023 Add to autocompletes?
 val hexColorMap = mapOf(
@@ -95,15 +96,10 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
             renderedPresets.add(rendered)
         }
 
-        val combined = renderedPresets.reduce { all, next ->
-            "<all>, <next>".render(mapOf(
-                "all" to all,
-                "next" to next,
-            ))
-        }
-
         val response = chattORE.config[ChattORESpec.format.chattore].render(
-            "Available pride presets: <message>".render(combined)
+            "Available presets: <message>".render(
+                Component.join(JoinConfiguration.commas(true), renderedPresets)
+            )
         )
         player.sendMessage(response)
     }

--- a/src/main/kotlin/commands/Nick.kt
+++ b/src/main/kotlin/commands/Nick.kt
@@ -95,7 +95,12 @@ class Nick(private val chattORE: ChattORE) : BaseCommand() {
             renderedPresets.add(rendered)
         }
 
-        val combined = renderedPresets.reduce { all, next -> "<all>, <next>".render(mapOf("all" to all, "next" to next )) }
+        val combined = renderedPresets.reduce { all, next ->
+            "<all>, <next>".render(mapOf(
+                "all" to all,
+                "next" to next,
+            ))
+        }
 
         val response = chattORE.config[ChattORESpec.format.chattore].render(
             "Available pride presets: <message>".render(combined)

--- a/src/main/kotlin/entity/ChattORESpec.kt
+++ b/src/main/kotlin/entity/ChattORESpec.kt
@@ -25,7 +25,7 @@ object ChattORESpec : ConfigSpec("") {
     }
 
     object format : ConfigSpec() {
-        val global by optional("<prefix> <gray>|</gray> <yellow><sender></yellow><gray>:</gray> <message>")
+        val global by optional("<prefix> <gray>|</gray> <hover:show_text:'<username> | <i>Click for more</i>'><yellow><sender></yellow></hover><gray>:</gray> <message>")
         val discord by optional("<dark_aqua>Discord</dark_aqua> <gray>|</gray> <dark_purple><sender></dark_purple><gray>:</gray> <message>")
         val mailReceived by optional("<gold>[</gold><red>From <sender></red><gold>]</gold> <message>")
         val mailSent by optional("<gold>[</gold><red>To <recipient></red><gold>]</gold> <message>")

--- a/src/main/kotlin/entity/ChattORESpec.kt
+++ b/src/main/kotlin/entity/ChattORESpec.kt
@@ -1,6 +1,7 @@
 package chattore.entity
 
 import com.uchuhimo.konf.ConfigSpec
+import chattore.pridePresets
 
 object ChattORESpec : ConfigSpec("") {
 
@@ -44,4 +45,6 @@ object ChattORESpec : ConfigSpec("") {
         val joinDiscord by optional("**<player> has joined the network**")
         val leaveDiscord by optional("**<player> has left the network**")
     }
+
+    val nicknamePresets by optional(pridePresets)
 }

--- a/src/main/kotlin/listener/ChatListener.kt
+++ b/src/main/kotlin/listener/ChatListener.kt
@@ -34,6 +34,7 @@ class ChatListener(
 
     @Subscribe
     fun joinEvent(event: LoginEvent) {
+        joinMessage(event)
         val unreadCount = chattORE.database.getMessages(event.player.uniqueId).filter { !it.read }.size
         if (unreadCount > 0)
             chattORE.proxy.scheduler.buildTask(chattORE, Runnable {
@@ -51,10 +52,7 @@ class ChatListener(
         chattORE.database.removeNickname(event.player.uniqueId)
     }
 
-    @Subscribe
-    fun joinMessage(event: ServerPostConnectEvent) {
-        if (event.player.uniqueId in chattORE.onlinePlayers) return
-        chattORE.onlinePlayers.add(event.player.uniqueId)
+    fun joinMessage(event: LoginEvent) {
         val username = event.player.username
         chattORE.broadcast(
             chattORE.config[ChattORESpec.format.join].render(mapOf(
@@ -71,8 +69,7 @@ class ChatListener(
 
     @Subscribe
     fun leaveMessage(event: DisconnectEvent) {
-        if (event.player.uniqueId !in chattORE.onlinePlayers) return
-        chattORE.onlinePlayers.remove(event.player.uniqueId)
+        if (event.loginStatus != DisconnectEvent.LoginStatus.SUCCESSFUL_LOGIN) return
         val username = event.player.username
         chattORE.broadcast(
             chattORE.config[ChattORESpec.format.leave].render(mapOf(

--- a/src/main/kotlin/listener/ChatListener.kt
+++ b/src/main/kotlin/listener/ChatListener.kt
@@ -46,6 +46,8 @@ class ChatListener(
         if (!chattORE.config[ChattORESpec.clearNicknameOnChange]) return
         val existingName = chattORE.database.uuidToUsernameCache[event.player.uniqueId] ?: return
         if (existingName == event.player.username) return
+        val nickname = chattORE.database.getNickname(event.player.uniqueId);
+        if (nickname?.contains("<username>") ?: false) return
         chattORE.database.removeNickname(event.player.uniqueId)
     }
 


### PR DESCRIPTION
With (default) presets taken from [hyfetch](https://github.com/hykilpikonna/hyfetch/blob/master/hyfetch/presets.py) (aka "gay neofetch"), this PR implements a ~~`/nick pride`~~ `/nick preset` command that sets your nickname to a one of the configured presets (by default, these are pride flags as gradients). ~~Using this command bypasses the normal 3-color limit to a nickname.~~ Presets are arbitrary MiniMessage format strings, so naturally they are not bound by the 3 color limit that the gradient command is capped at. It has full support for command completions. There is also a command `/nick presets` which prints out a nice message showing how all the ~~pride flags~~ presets look.

Here's what it all looks like

![image](https://github.com/OpenRedstoneEngineers/ChattORE/assets/37938646/0a1a715d-2393-4a1c-bf6a-13b6e0d2abad)

\* Note that this screenshot does not show the current version of the PR. However, they are visually indistinguishable apart from the fact that `/nick pride` has been renamed to `/nick preset` and some wording may have changed. It still shows off properly how this looks in the chat.

The default presets are all gradients, but a preset may have arbitrary MiniMessage formatting, such as bold, italics, underline, or other decorative characters before/after like `[<username>]` will display in-game as `[sodiboo]`. Staff can manually set a nickname using the same format as the presets, although they do not need to use `<username>`, they can set an arbitrary name. If they do not use `<username>` for the name itself, the nickname will be reset when that player changes their username. If the nickname uses the `<username>` tag (which all presets do), it is automatically updated, but not reset or removed, when the player changes their username.

---

This PR also makes another more technical change: Previously, this plugin would not show messages for players without a LuckPerms prefix. Now, we fall back to the group name if there is no prefix, rather than aborting. We also make the first character uppercase. If that's also null, the literal string "No Group" is shown (this happens... i think never? i tried deleting the default group; luckperms wouldn't let me)

This was very confusing when setting up the plugin on my own server. Messages were not being shown, with no reason given why not.