### PR TITLE
Slew of formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ Because we want to have a chat system that actually wOREks for us.
 
 ## Commands
 
-| Command                               | Permission                      | Description                                              | Aliases                                   |
-|---------------------------------------|---------------------------------|----------------------------------------------------------|-------------------------------------------|
-| `/chattore version`                   | `chattore.manage`               | View the version of Chattore                             | No aliases                                |
-| `/chattore reload`                    | `chattore.manage`               | Reload Chattore configuration                            | No aliases                                |
-| `/emoji <emoji_names>+`               | `chattore.emoji`                | View multiple emojis                                     | No aliases                                |
-| `/ac <message>`                       | `chattore.helpop`               | Message ORE Staff                                        | No aliases                                |
-| `/mail mailbox`                       | `chattore.mail`                 | Manage your mailbox                                      | `/mailbox\|/mail`                         |
-| `/mail send <player> <message>`       | `chattore.mail`                 | Send a mail message                                      | No aliases                                |
-| `/mail read <mail ID>`                | `chattore.mail`                 | Read a mail message (Designed for usage with `/mailbox`) | No aliases                                |
-| `/me <message>`                       | `chattore.me`                   | Have a thought in chat                                   | No aliases                                |
-| `/message <player> <message>`         | `chattore.message`              | Send a message to a player                               | `/msg\|/vmsg\|/vmessage\|/whisper\|/tell` |
-| `/reply <message>`                    | `chattore.message`              | Reply to a message                                       | `/playerprofile`                          |
-| `/profile info <player>`              | `chattore.profile`              | View a player's profile                                  | `/playerprofile`                          |
-| `/profile about <player>`             | `chattore.profile.about`        | Set your about                                           | `/playerprofile`                          |
-| `/profile setabout <player> <about>`  | `chattore.profile.about.others` | Set another player's about                               | `/playerprofile`                          |
-| `/nick <color>+`                      | `chattore.nick`                 | Set your nickname with at least one color (up to three)  | No aliases                                |
-| `/nick nick <player> <nickname>`      | `chattore.nick.others`          | Set a player's nickname                                  | No aliases                                |
-| `/nick remove <player>`               | `chattore.nick.remove`          | Remove a player's nickname                               | No aliases                                |
-| `/nick setgradient <player> <color>+` | `chattore.nick.setgradient`     | Set a gradient for a user                                | No aliases                                |
+| Command                               | Permission                      | Description                                              | Aliases                                       |
+|---------------------------------------|---------------------------------|----------------------------------------------------------|-----------------------------------------------|
+| `/chattore version`                   | `chattore.manage`               | View the version of Chattore                             | No aliases                                    |
+| `/chattore reload`                    | `chattore.manage`               | Reload Chattore configuration                            | No aliases                                    |
+| `/emoji <emoji_names>+`               | `chattore.emoji`                | View multiple emojis                                     | No aliases                                    |
+| `/ac <message>`                       | `chattore.helpop`               | Message ORE Staff                                        | No aliases                                    |
+| `/mail mailbox`                       | `chattore.mail`                 | Manage your mailbox                                      | `/mailbox\|/mail`                             |
+| `/mail send <player> <message>`       | `chattore.mail`                 | Send a mail message                                      | No aliases                                    |
+| `/mail read <mail ID>`                | `chattore.mail`                 | Read a mail message (Designed for usage with `/mailbox`) | No aliases                                    |
+| `/me <message>`                       | `chattore.me`                   | Have a thought in chat                                   | No aliases                                    |
+| `/message <player> <message>`         | `chattore.message`              | Send a message to a player                               | `/m\|/msg\|/vmsg\|/vmessage\|/whisper\|/tell` |
+| `/reply <message>`                    | `chattore.message`              | Reply to a message                                       | `/playerprofile`                              |
+| `/profile info <player>`              | `chattore.profile`              | View a player's profile                                  | `/playerprofile`                              |
+| `/profile about <player>`             | `chattore.profile.about`        | Set your about                                           | `/playerprofile`                              |
+| `/profile setabout <player> <about>`  | `chattore.profile.about.others` | Set another player's about                               | `/playerprofile`                              |
+| `/nick <color>+`                      | `chattore.nick`                 | Set your nickname with at least one color (up to three)  | No aliases                                    |
+| `/nick nick <player> <nickname>`      | `chattore.nick.others`          | Set a player's nickname                                  | No aliases                                    |
+| `/nick remove <player>`               | `chattore.nick.remove`          | Remove a player's nickname                               | No aliases                                    |
+| `/nick setgradient <player> <color>+` | `chattore.nick.setgradient`     | Set a gradient for a user                                | No aliases                                    |

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -63,8 +63,8 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     private val dataFolder = dataFolder.toFile()
     private val uuidRegex = """[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""".toRegex()
     private var chatReplacements: MutableList<TextReplacementConfig> = mutableListOf(
-        formatReplacement("\\*\\*", "b"),
-        formatReplacement("\\*", "i"),
+        formatReplacement("**", "b"),
+        formatReplacement("*", "i"),
         formatReplacement("__", "u"),
         formatReplacement("~~", "st")
     )

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -340,7 +340,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             val text = matchResult.groupValues[1].trim()
             val url = matchResult.groupValues[2].trim()
             "$text: $url"
-        }
+        }.replace("""\s+""".toRegex(), " ")
         broadcast(
             config[ChattORESpec.format.discord].render(
                 mapOf(

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -248,7 +248,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
                 this.replace("&k", "")
             }
         val canObfuscate = player?.hasPermission("chattore.chat.obfuscate") ?: false
-        val urlRegex = """<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s',.<>]+)?)>?""".toRegex()
+        val urlRegex = """<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s'<>]+)?)>?""".toRegex()
         val parts = urlRegex.split(message)
         val matches = urlRegex.findAll(message).iterator()
         val builder = Component.text()
@@ -261,10 +261,10 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
                 var name = link.host
                 if (link.file.isNotEmpty()) {
                     val last = link.path.split("/").last()
-                    if (last.contains('.')) {
+                    if (last.contains('.') && !last.endsWith('.') && !last.startsWith('.')) {
                         type = last.split('.').last()
-                        name = if (last.length > 20) {
-                            last.substring(0, 20) + "…." + type
+                        name = if (last.length > 15) {
+                            last.substring(0, 15) + "…." + type
                         } else {
                             last
                         }

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -36,6 +36,7 @@ import org.javacord.api.DiscordApiBuilder
 import org.javacord.api.entity.message.MessageBuilder
 import org.slf4j.Logger
 import java.io.File
+import java.net.URL
 import java.nio.file.Path
 import java.util.*
 
@@ -58,6 +59,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     val onlinePlayers: MutableSet<UUID> = Collections.synchronizedSet(mutableSetOf())
     private val replyMap: MutableMap<UUID, UUID> = hashMapOf()
     private var discordMap: Map<String, DiscordApi> = hashMapOf()
+    private var fileTypeMap: Map<String, List<String>> = hashMapOf()
     private var emojis: Map<String, String> = hashMapOf()
     private var emojisToNames: Map<String, String> = hashMapOf()
     private val dataFolder = dataFolder.toFile()
@@ -85,10 +87,9 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         }
         this.javaClass.getResourceAsStream("/filetypes.json")?.let { inputStream ->
             val jsonElement = Json.parseToJsonElement(inputStream.reader().readText())
-            val fileTypeMap = jsonElement.jsonObject.mapValues { (_, value) ->
+            fileTypeMap = jsonElement.jsonObject.mapValues { (_, value) ->
                 value.jsonArray.map { it.jsonPrimitive.content }
             }
-            chatReplacements.add(urlReplacementConfig(fileTypeMap))
             fileTypeMap.forEach { (key, values) ->
                 logger.info("Loaded ${values.size} of type $key")
             }
@@ -216,19 +217,13 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         targetPlayer: Player,
         args: Array<String>
     ) {
-        var statement = args.joinToString(" ")
-        if (!player.hasPermission("chattore.chat.obfuscate") && statement.contains("&k")) {
-            player.sendMessage(config[ChattORESpec.format.error].render(mapOf(
-                "message" to "You do not have permission to obfuscate text!".toComponent()
-            )))
-            statement = statement.replace("&k", "")
-        }
+        val statement = args.joinToString(" ")
         logger.info("${player.username} (${player.uniqueId}) -> " +
             "${targetPlayer.username} (${targetPlayer.uniqueId}): $statement")
         player.sendMessage(
             config[ChattORESpec.format.messageSent].render(
                 mapOf(
-                    "message" to statement.prepareChatMessage(chatReplacements),
+                    "message" to prepareChatMessage(statement, player),
                     "recipient" to targetPlayer.username.toComponent()
                 )
             )
@@ -236,13 +231,61 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         targetPlayer.sendMessage(
             config[ChattORESpec.format.messageReceived].render(
                 mapOf(
-                    "message" to statement.prepareChatMessage(chatReplacements),
+                    "message" to prepareChatMessage(statement, player),
                     "sender" to player.username.toComponent()
                 )
             )
         )
         replyMap[targetPlayer.uniqueId] = player.uniqueId
         replyMap[player.uniqueId] = targetPlayer.uniqueId
+    }
+
+    private fun prepareChatMessage(message: String, player: Player?): Component {
+        fun String.replaceObfuscate(canObfuscate: Boolean): String =
+            if (canObfuscate) {
+                this
+            } else {
+                this.replace("&k", "")
+            }
+        val canObfuscate = player?.hasPermission("chattore.chat.obfuscate") ?: false
+        val urlRegex = """<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s'<>]+)?)>?""".toRegex()
+        val parts = urlRegex.split(message)
+        val matches = urlRegex.findAll(message).iterator()
+        val builder = Component.text()
+        parts.forEach { part ->
+            builder.append(part.replaceObfuscate(canObfuscate).legacyDeserialize())
+            if (matches.hasNext()) {
+                val nextMatch = matches.next()
+                val link = URL(nextMatch.groupValues[1])
+                var type = "link"
+                var name = link.host
+                if (link.file.isNotEmpty()) {
+                    val last = link.path.split("/").last()
+                    if (last.contains('.')) {
+                        type = last.split('.').last()
+                        name = if (last.length > 20) {
+                            last.substring(0, 20) + "…." + type
+                        } else {
+                            last
+                        }
+                    }
+                }
+                val contentType = fileTypeMap.entries.find { type in it.value }?.key
+                val symbol = when (contentType) {
+                    "IMAGE" -> "\uD83D\uDDBC"
+                    "AUDIO" -> "\uD83D\uDD0A"
+                    "VIDEO" -> "\uD83C\uDFA5"
+                    "TEXT" -> "\uD83D\uDCDD"
+                    else -> "\uD83D\uDCCE"
+                }
+                builder.append(("<aqua><click:open_url:'$link'>" +
+                    "<hover:show_text:'<aqua>$link'>" +
+                    "[$symbol $name]" +
+                    "</hover>" +
+                    "</click><reset>").miniMessageDeserialize())
+            }
+        }
+        return builder.build().performReplacements(chatReplacements)
     }
 
     fun broadcast(component: Component) {
@@ -269,7 +312,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
         broadcast(
             config[ChattORESpec.format.global].render(
                 mapOf(
-                    "message" to message.prepareChatMessage(chatReplacements),
+                    "message" to prepareChatMessage(message, player),
                     "sender" to sender,
                     "prefix" to prefix.legacyDeserialize()
                 )
@@ -302,7 +345,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
             config[ChattORESpec.format.discord].render(
                 mapOf(
                     "sender" to sender.toComponent(),
-                    "message" to transformedMessage.prepareChatMessage(chatReplacements)
+                    "message" to prepareChatMessage(transformedMessage, null)
                 )
             )
         )

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -248,7 +248,7 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
                 this.replace("&k", "")
             }
         val canObfuscate = player?.hasPermission("chattore.chat.obfuscate") ?: false
-        val urlRegex = """<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s'<>]+)?)>?""".toRegex()
+        val urlRegex = """<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s',.<>]+)?)>?""".toRegex()
         val parts = urlRegex.split(message)
         val matches = urlRegex.findAll(message).iterator()
         val builder = Component.text()

--- a/src/main/kotlin/ChattORE.kt
+++ b/src/main/kotlin/ChattORE.kt
@@ -256,11 +256,17 @@ class ChattORE @Inject constructor(val proxy: ProxyServer, val logger: Logger, @
     }
 
     fun broadcastDiscordMessage(sender: String, message: String) {
+        val urlMarkdownRegex = """\[([^]]*)\]\(\s?(\S+)\s?\)""".toRegex()
+        val transformedMessage = message.replace(urlMarkdownRegex) { matchResult ->
+            val text = matchResult.groupValues[1].trim()
+            val url = matchResult.groupValues[2].trim()
+            "$text: $url"
+        }
         broadcast(
             config[ChattORESpec.format.discord].render(
                 mapOf(
                     "sender" to sender.toComponent(),
-                    "message" to message.prepareChatMessage(chatReplacements)
+                    "message" to transformedMessage.prepareChatMessage(chatReplacements)
                 )
             )
         )

--- a/src/main/kotlin/Messaging.kt
+++ b/src/main/kotlin/Messaging.kt
@@ -25,7 +25,7 @@ fun String.discordEscape() = this.replace("""_""", "\\_")
 
 fun buildEmojiReplacement(emojis: Map<String, String>): TextReplacementConfig =
     TextReplacementConfig.builder()
-        .match(""":([A-Za-z0-9_]+):""")
+        .match(""":([A-Za-z0-9_\-+]+):""")
         .replacement { result, _ ->
             val match = result.group(1)
             val content = emojis[match] ?: ":$match:"

--- a/src/main/kotlin/Messaging.kt
+++ b/src/main/kotlin/Messaging.kt
@@ -5,7 +5,6 @@ import net.kyori.adventure.text.TextReplacementConfig
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
-import java.net.URL
 
 fun fixHexFormatting(str: String): String = str.replace(Regex("#([0-9a-f]{6})")) { "&${it.groupValues.first()}" }
 

--- a/src/main/kotlin/Messaging.kt
+++ b/src/main/kotlin/Messaging.kt
@@ -46,42 +46,8 @@ fun formatReplacement(key: String, tag: String): TextReplacementConfig =
         }
         .build()
 
-fun urlReplacementConfig(fileTypeMap: Map<String, List<String>>): TextReplacementConfig =
-    TextReplacementConfig.builder()
-        .match("""<?((http|https)://([\w_-]+(?:\.[\w_-]+)+)([^\s'<>]+)?)>?""")
-        .replacement{ result, _ ->
-            val link = URL(result.group(1))
-            var type = "link"
-            var name = link.host
-            if (link.file.isNotEmpty()) {
-                val last = link.path.split("/").last()
-                if (last.contains('.')) {
-                    type = last.split('.').last()
-                    name = if (last.length > 20) {
-                        last.substring(0, 20) + "…." + type
-                    } else {
-                        last
-                    }
-                }
-            }
-            val contentType = fileTypeMap.entries.find { type in it.value }?.key
-            val symbol = when (contentType) {
-                "IMAGE" -> "\uD83D\uDDBC"
-                "AUDIO" -> "\uD83D\uDD0A"
-                "VIDEO" -> "\uD83C\uDFA5"
-                "TEXT" -> "\uD83D\uDCDD"
-                else -> "\uD83D\uDCCE"
-            }
-            ("<aqua><click:open_url:'$link'>" +
-            "<hover:show_text:'<aqua>$link'>" +
-            "[$symbol $name]" +
-            "</hover>" +
-            "</click><reset>").miniMessageDeserialize()
-        }
-        .build()
-
-fun String.prepareChatMessage(replacements: List<TextReplacementConfig>): Component {
-    var result: Component = this.legacyDeserialize()
+fun Component.performReplacements(replacements: List<TextReplacementConfig>): Component {
+    var result: Component = this
     replacements.forEach { replacement ->
         result = result.replaceText(replacement)
     }

--- a/src/main/kotlin/commands/Message.kt
+++ b/src/main/kotlin/commands/Message.kt
@@ -5,8 +5,6 @@ import co.aikar.commands.BaseCommand
 import co.aikar.commands.annotation.*
 import com.uchuhimo.konf.Config
 import com.velocitypowered.api.proxy.Player
-import chattore.entity.ChattORESpec
-import org.slf4j.Logger
 import java.util.*
 
 @CommandAlias("m|msg|message|vmsg|vmessage|whisper|tell")
@@ -22,56 +20,9 @@ class Message(
     @CommandCompletion("@players")
     fun default(player: Player, target: String, args: Array<String>) {
         chattORE.proxy.getPlayer(target).ifPresentOrElse({ targetPlayer ->
-            sendMessage(
-                chattORE.logger,
-                replyMap,
-                config,
-                player,
-                targetPlayer,
-                args,
-                chattORE.config[ChattORESpec.format.error]
-            )
+            chattORE.sendMessage(replyMap, config, player, targetPlayer, args)
         }, {
             throw ChattoreException("That user doesn't exist!")
         })
     }
-}
-
-// I don't like putting this here but eggsdee we'll figure out a better place later
-fun sendMessage(
-    logger: Logger,
-    replyMap: MutableMap<UUID, UUID>,
-    config: Config,
-    player: Player,
-    targetPlayer: Player,
-    args: Array<String>,
-    errorTemplate: String
-) {
-    var statement = args.joinToString(" ")
-    if (!player.hasPermission("chattore.chat.obfuscate") && statement.contains("&k")) {
-        player.sendMessage(errorTemplate.render(mapOf(
-            "message" to "You do not have permission to obfuscate text!".toComponent()
-        )))
-        statement = statement.replace("&k", "")
-    }
-    logger.info("${player.username} (${player.uniqueId}) -> " +
-        "${targetPlayer.username} (${targetPlayer.uniqueId}): $statement")
-    player.sendMessage(
-        config[ChattORESpec.format.messageSent].render(
-            mapOf(
-                "message" to statement.legacyDeserialize(),
-                "recipient" to targetPlayer.username.toComponent()
-            )
-        )
-    )
-    targetPlayer.sendMessage(
-        config[ChattORESpec.format.messageReceived].render(
-            mapOf(
-                "message" to statement.legacyDeserialize(),
-                "sender" to player.username.toComponent()
-            )
-        )
-    )
-    replyMap[targetPlayer.uniqueId] = player.uniqueId
-    replyMap[player.uniqueId] = targetPlayer.uniqueId
 }

--- a/src/main/kotlin/commands/Message.kt
+++ b/src/main/kotlin/commands/Message.kt
@@ -9,7 +9,7 @@ import chattore.entity.ChattORESpec
 import org.slf4j.Logger
 import java.util.*
 
-@CommandAlias("msg|message|vmsg|vmessage|whisper|tell")
+@CommandAlias("m|msg|message|vmsg|vmessage|whisper|tell")
 @CommandPermission("chattore.message")
 class Message(
     private val config: Config,
@@ -54,7 +54,8 @@ fun sendMessage(
         )))
         statement = statement.replace("&k", "")
     }
-    logger.info("${player.username} -> ${targetPlayer.username}: $statement")
+    logger.info("${player.username} (${player.uniqueId}) -> " +
+        "${targetPlayer.username} (${targetPlayer.uniqueId}): $statement")
     player.sendMessage(
         config[ChattORESpec.format.messageSent].render(
             mapOf(

--- a/src/main/kotlin/commands/Reply.kt
+++ b/src/main/kotlin/commands/Reply.kt
@@ -2,7 +2,6 @@ package chattore.commands
 
 import chattore.ChattORE
 import chattore.ChattoreException
-import chattore.entity.ChattORESpec
 import co.aikar.commands.BaseCommand
 import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.CommandPermission

--- a/src/main/kotlin/commands/Reply.kt
+++ b/src/main/kotlin/commands/Reply.kt
@@ -26,15 +26,7 @@ class Reply(
                 "You have no one to reply to!"
             )
         ).ifPresentOrElse({ target ->
-            sendMessage(
-                chattORE.logger,
-                replyMap,
-                config,
-                player,
-                target,
-                args,
-                chattORE.config[ChattORESpec.format.error]
-            )
+            chattORE.sendMessage(replyMap, config, player, target, args)
         }, {
             throw ChattoreException(
                 "The person you are trying to reply to is no longer online!"

--- a/src/main/kotlin/listener/ChatListener.kt
+++ b/src/main/kotlin/listener/ChatListener.kt
@@ -1,6 +1,7 @@
 package chattore.listener
 
 import chattore.ChattORE
+import chattore.discordEscape
 import chattore.entity.ChattORESpec
 import chattore.render
 import chattore.toComponent
@@ -62,7 +63,7 @@ class ChatListener(
         chattORE.broadcastPlayerConnection(
             chattORE.config[ChattORESpec.format.joinDiscord].replace(
                 "<player>",
-                username
+                username.discordEscape()
             )
         )
     }
@@ -80,7 +81,7 @@ class ChatListener(
         chattORE.broadcastPlayerConnection(
             chattORE.config[ChattORESpec.format.leaveDiscord].replace(
                 "<player>",
-                username
+                username.discordEscape()
             )
         )
     }

--- a/src/main/kotlin/listener/ChatListener.kt
+++ b/src/main/kotlin/listener/ChatListener.kt
@@ -90,14 +90,7 @@ class ChatListener(
         val pp = event.player
         pp.currentServer.ifPresent { server ->
             chattORE.logger.info("${pp.username} (${pp.uniqueId}): ${event.message}")
-            var result = event.message
-            if (event.message.contains("&k") && !pp.hasPermission("chattore.chat.obfuscate")) {
-                pp.sendMessage(chattORE.config[ChattORESpec.format.error].render(mapOf(
-                    "message" to "You do not have permission to obfuscate text!".toComponent()
-                )))
-                result = event.message.replace("&k", "")
-            }
-            chattORE.broadcastChatMessage(server.serverInfo.name, pp.uniqueId, result)
+            chattORE.broadcastChatMessage(server.serverInfo.name, pp.uniqueId, event.message)
         }
     }
 

--- a/src/main/kotlin/listener/DiscordListener.kt
+++ b/src/main/kotlin/listener/DiscordListener.kt
@@ -24,7 +24,7 @@ class DiscordListener(
     override fun onMessageCreate(event: MessageCreateEvent) {
         if (event.messageAuthor.isBotUser && event.messageAuthor.id != chattORE.config[ChattORESpec.discord.chadId]) return
         val attachments = event.messageAttachments.joinToString(" ", " ") { it.url.toString() }
-        val toSend = replaceEmojis(event.message.readableContent.replace("&k", "")) + attachments
+        val toSend = replaceEmojis(event.message.readableContent) + attachments
         chattORE.logger.info("[Discord] ${event.messageAuthor.displayName} (${event.messageAuthor.id}): $toSend")
         chattORE.broadcastDiscordMessage(event.messageAuthor.displayName, toSend)
     }


### PR DESCRIPTION
Fixes:

- DMs not being logged with UUIDs.
- DMs not being parsed for URLs or Emojis.
- Markdown URLs not being parsed properly.
- Not being able to escape markdown formatting.
- URLs with a legacy color code causing formatting problems.
- Names with underscores not being escaped in join/leave messages.
- URLs ending with a `.` being parsed as a file.
- Discord messages with newlines being on multiple lines.
- Emoji regex not including `:+1:` and `:-1:`.