### PR TITLE
Refactor: Replace JavaCord with Kord

### DIFF
--- a/chattore/build.gradle.kts
+++ b/chattore/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 dependencies {
     implementation(project(":common"))
     implementation(libs.acf)
-    implementation(libs.javacord)
+    implementation(libs.kord)
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.javaTime)

--- a/chattore/src/main/kotlin/feature/Alias.kt
+++ b/chattore/src/main/kotlin/feature/Alias.kt
@@ -20,12 +20,12 @@ import org.slf4j.Logger
 
 private val IDENTIFIER: MinecraftChannelIdentifier = MinecraftChannelIdentifier.from(ALIAS_CHANNEL)
 
-private val argumentsRegex = Regex("\\\$(args|[0-9]+)")
+private val argumentsRegex = Regex("""\$(args|[0-9]+)""")
 
 @Serializable
 data class AliasConfig(
-    val alias: String = "alias",
-    val commands: List<String> = listOf("some", "commands"),
+    val alias: String,
+    val commands: List<String>,
 )
 
 fun PluginScope.createAliasFeature() {
@@ -53,7 +53,8 @@ private class AliasCommand(
 
     private val requiredArgs = commands.flatMap {
         argumentsRegex.findAll(it).map { match ->
-            match.groupValues[1].toIntOrNull()?.plus(1) ?: 1
+            // require 0 for "args"
+            match.groupValues[1].toIntOrNull()?.plus(1) ?: 0
         }
     }.maxOrNull() ?: 0
 

--- a/chattore/src/main/resources/aliases.json
+++ b/chattore/src/main/resources/aliases.json
@@ -26,7 +26,7 @@
   {
     "alias": "nv",
     "commands": [
-      "effect give $1 minecraft:night_vision infinite"
+      "effect give $0 minecraft:night_vision infinite"
     ]
   },
   {
@@ -83,14 +83,14 @@
     "alias": "/hs",
     "commands": [
       "/hpos2",
-      "/rs $1 1"
+      "/rs $0 1"
     ]
   },
   {
     "alias": "/me",
     "commands": [
       "/hpos2",
-      "/replace $1 air"
+      "/replace $0 air"
     ]
   },
   {
@@ -127,41 +127,41 @@
   {
     "alias": "/s",
     "commands": [
-      "/stack $1"
+      "/stack $args"
     ]
   },
   {
     "alias": "/sa",
     "commands": [
-      "/stack -a $1"
+      "/stack -a $args"
     ]
   },
   {
     "alias": "/su",
     "commands": [
       "/hpos2",
-      "/stack $1 u"
+      "/stack $0 u"
     ]
   },
   {
     "alias": "/sd",
     "commands": [
       "/hpos2",
-      "/stack $1 d"
+      "/stack $0 d"
     ]
   },
   {
     "alias": "/sl",
     "commands": [
       "/hpos2",
-      "/stack $1 l"
+      "/stack $0 l"
     ]
   },
   {
     "alias": "/sr",
     "commands": [
       "/hpos2",
-      "/stack $1 r"
+      "/stack $0 r"
     ]
   },
   {
@@ -173,49 +173,49 @@
   {
     "alias": "/r",
     "commands": [
-      "/rotate $1"
+      "/rotate $args"
     ]
   },
   {
     "alias": "/u",
     "commands": [
-      "/undo $1"
+      "/undo $args"
     ]
   },
   {
     "alias": "/z",
     "commands": [
-      "/undo"
+      "/undo $args"
     ]
   },
   {
     "alias": "/y",
     "commands": [
-      "/redo"
+      "/redo $args"
     ]
   },
   {
     "alias": "/m",
     "commands": [
-      "/move $1"
+      "/move $args"
     ]
   },
   {
     "alias": "/md",
     "commands": [
-      "/move $1 $2"
+      "/move $0 d"
     ]
   },
   {
     "alias": "/ma",
     "commands": [
-      "/move $1 -a"
+      "/move -a $args"
     ]
   },
   {
     "alias": "/mas",
     "commands": [
-      "/move $1 -a -s"
+      "/move -as $args"
     ]
   },
   {
@@ -230,7 +230,7 @@
   {
     "alias": "/e",
     "commands": [
-      "/expand $1"
+      "/expand $args"
     ]
   },
   {
@@ -244,6 +244,14 @@
     "alias": "/cfv",
     "commands": [
       "/copy",
+      "/flip",
+      "/paste -a"
+    ]
+  },
+  {
+    "alias": "/xfv",
+    "commands": [
+      "/cut",
       "/flip",
       "/paste -a"
     ]

--- a/chattore/src/main/resources/commands.json
+++ b/chattore/src/main/resources/commands.json
@@ -159,7 +159,7 @@
   {
     "command": "redcmd",
     "description": "intal gento",
-    "globalChat": "<red>Hello allo"
+    "globalChat": "<gray><name><white>: <red>Hello allo"
   },
   {
     "command": "lag",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ jackson = "2.19.0"
 
 [libraries]
 acf = "co.aikar:acf-velocity:0.5.1-SNAPSHOT"
-javacord = "org.javacord:javacord:3.8.0"
+kord = "dev.kord:kord-core:0.17.0"
 sqliteJdbc = "org.xerial:sqlite-jdbc:3.46.0.0"
 luckperms = "net.luckperms:api:5.1"
 paper = "io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT"


### PR DESCRIPTION
JavaCord is not maintained anymore and seems to be causing us some trouble.
With these changes, messages from Discord should show the correct display name of the sender, but mentions should consistently not be resolved (so all of them look like `<@user id>`; this is how it is intended to work right now, but apparently JavaCord does something weird with them). We should work on a better parser later that can resolve mentions.